### PR TITLE
예전 한국어 문서에 이전 안내 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 ## 다운로드
 
 [Releases](https://github.com/karpitony/eft-where-am-i/releases)에서
-최신 버전의 `.zip` 파일을 다운로드 받으실 수 있습니다. 다운받은 원하는 위치에서
+최신 버전의 `.zip` 파일을 다운로드 받으실 수 있습니다. 다운받은 후 원하는 위치에서
 압축을 풀고 `eft-where-am-i.exe`를 실행하시면 됩니다. 보안 경고가 표시될 수
-있습니다. 바이러스는 없으니 `추가 정보`를 눌러 `실행`을 눌러주세요. [VirusTotal](https://www.virustotal.com/gui/file/4aa4768640a4c29ddc42ad1bc736d70c98630149985477e153bdae93aa91f010/detection)
+있으나, 바이러스는 없으니 `추가 정보`를 눌러 `실행`을 눌러주세요. [VirusTotal](https://www.virustotal.com/gui/file/4aa4768640a4c29ddc42ad1bc736d70c98630149985477e153bdae93aa91f010/detection)
 
 ![exe](assets/eft-wmi-exe.png)
 

--- a/README_ko_kr.md
+++ b/README_ko_kr.md
@@ -1,0 +1,3 @@
+# 문서 이전 안내
+
+한국어 문서는 [여기로](https://github.com/karpitony/eft-where-am-i) 이동되었습니다.


### PR DESCRIPTION
구글 검새 결과에서는 여전히 ko_kr 문서가 상위권을 차지하고 있습니다.
얼마전 README를 한국어로 교체하면서 README_ko_kr.md를 삭제했었는데
구글에선 404 페이지로 이어지게 되었습니다.

다시 파일을 만들고 이전한 URL을 링크로 걸어두었습니다.