### PR TITLE
tarkov-market Where am I 버튼 class 변경으로 인한 버튼 인식 오류 수정

### DIFF
--- a/eft-where-am-i/Classes/Constants.cs
+++ b/eft-where-am-i/Classes/Constants.cs
@@ -6,7 +6,7 @@ namespace eft_where_am_i.Classes
 
         public const string FULL_SCREEN_BUTTON_SELECTOR = "#__nuxt > div > div > div.page-content > div > div > div.panel_top > div > button";
 
-        public const string WHERE_AM_I_BUTTON_SELECTOR = "#__nuxt > div > div > div.page-content > div > div > div.panel_top > div > div.d-flex.ml-15.fs-0 > button";
+        public const string WHERE_AM_I_BUTTON_SELECTOR = "#__nuxt > div > div > div.page-content > div > div > div.panel_top > div > div.d-flex.ml-15 > button";
 
         /*
          * The following code (ADD_DIRECTION_INDICATORS_SCRIPT) is from 'Tarkov-Client' by 'byeong1'


### PR DESCRIPTION
최근 업데이트로 Tarkov Market Maps의 "Where am I?" 버튼의 클래스가 수정되어 작동하지 않는 오류를 수정하였습니다.

<img width="451" height="60" alt="image" src="https://github.com/user-attachments/assets/369785aa-165d-4103-89fc-ef2ec4c27424" />
