### PR TITLE
퀘스트 클릭시 옆 패널도 같이열리는 문제 fix

### DIFF
--- a/eft-where-am-i/Classes/JavaScriptExecutor.cs
+++ b/eft-where-am-i/Classes/JavaScriptExecutor.cs
@@ -84,6 +84,13 @@ namespace eft_where_am_i.Classes
         {
             string script = $@"
             (function() {{
+                // Prefer the specific input inside panel_top > div:nth-child(4)
+                var preferred = document.querySelector('#__nuxt > div > div > div.page-content > div > div > div.panel_top > div > div:nth-child(4) > input[type=text]');
+                if (preferred) {{
+                    const isVisibleP = preferred.offsetParent !== null;
+                    const isEnabledP = !preferred.disabled && !preferred.readOnly;
+                    if (isVisibleP && isEnabledP) return true;
+                }}
                 const buttons = document.querySelectorAll('button');
                 for (const btn of buttons) {{
                     if (btn.textContent.trim() === 'Where am i?') {{
@@ -127,19 +134,51 @@ namespace eft_where_am_i.Classes
             string script = $@"
                 (function() {{
                     var input = document.querySelector({Selector});
-                    if (!input) {{ console.log('Input not found'); return; }}
+
+                    // Prefer specific input inside panel_top > div:nth-child(4)
+                    try {{
+                        var preferred = document.querySelector('#__nuxt > div > div > div.page-content > div > div > div.panel_top > div > div:nth-child(4) > input[type=text]');
+                        if (preferred) input = preferred;
+                    }} catch(e) {{}}
+
+                    // Fallbacks: try to locate input near a 'Where' button, placeholder inputs, or any text input
+                    if (!input) {{
+                        try {{
+                            var buttons = document.querySelectorAll('button');
+                            for (var i=0;i<buttons.length;i++) {{
+                                var t = (buttons[i].textContent || '').toLowerCase();
+                                if (t.indexOf('where') !== -1 || t.indexOf('where am') !== -1) {{
+                                    var p = buttons[i].parentElement || buttons[i].closest('div');
+                                    if (p) {{
+                                        input = p.querySelector('input, input[type=text]');
+                                        if (input) break;
+                                    }}
+                                }}
+                            }}
+                        }} catch (e) {{ console.log('Fallback button search failed: ' + e.message); }}
+                    }}
+
+                    if (!input) {{
+                        input = document.querySelector('input[placeholder]') || document.querySelector('input[type=text]') || document.querySelector('input');
+                    }}
+
+                    if (!input) {{ console.log('Input not found (all fallbacks)'); return; }}
 
                     // Use native setter to bypass Vue/React getter/setter
                     var nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
                     nativeSetter.call(input, {escapedValue});
 
                     // Dispatch multiple events for framework compatibility
-                    input.dispatchEvent(new InputEvent('input', {{ bubbles: true, cancelable: true, inputType: 'insertText', data: {escapedValue} }}));
+                    try {{
+                        input.dispatchEvent(new InputEvent('input', {{ bubbles: true, cancelable: true, inputType: 'insertText', data: {escapedValue} }}));
+                    }} catch(e) {{
+                        // Some browsers/environments may not support InputEvent constructor
+                        var ev = document.createEvent('Event'); ev.initEvent('input', true, true); input.dispatchEvent(ev);
+                    }}
                     input.dispatchEvent(new Event('change', {{ bubbles: true }}));
 
                     // Also try focus/blur to trigger validation
-                    input.focus();
-                    input.blur();
+                    try {{ input.focus(); input.blur(); }} catch(e) {{}}
 
                     console.log('Input value set to: ' + input.value);
                 }})();";

--- a/eft-where-am-i/UserControls/WhereAmI.cs
+++ b/eft-where-am-i/UserControls/WhereAmI.cs
@@ -553,43 +553,74 @@ namespace eft_where_am_i
 
         private async void CoreWebView2_SourceChanged(object sender, CoreWebView2SourceChangedEventArgs e)
         {
-            // URL 변경을 감지하고, "tarkov-market.com/maps/맵이름" 인 경우 내부 상태 업데이트 및 스크립트 재주입
+            // URL 변경 감지: 맵 slug(/maps/{slug})가 실제로 바뀐 경우에만 복원 로직 실행
             string currentUrl = webView2.Source?.ToString();
-            if (currentUrl != null && currentUrl.Contains("/maps/"))
+            string mapName = TryExtractMapNameFromUrl(currentUrl);
+            if (string.IsNullOrEmpty(mapName))
             {
-                string mapName = currentUrl.Substring(currentUrl.LastIndexOf('/') + 1);
+                return;
+            }
 
-                // 기존 설정과 다르다면 맵이 변경된 것으로 간주 (마켓 웹 내부에서 다른 맵을 클릭한 경우)
-                if (!string.Equals(appSettings.latest_map, mapName, StringComparison.OrdinalIgnoreCase))
+            bool mapChanged = !string.Equals(appSettings.latest_map, mapName, StringComparison.OrdinalIgnoreCase);
+            if (!mapChanged)
+            {
+                // 같은 맵 내부에서 발생한 SourceChanged(예: 퀘스트 이미지 열기)에는 패널 복원을 하지 않음
+                return;
+            }
+
+            appSettings.latest_map = mapName;
+            SaveSettings();
+
+            // UI 패널(WhereAmIPanel)의 ComboBox 상태도 함께 변경
+            if (webView2_panel_ui.CoreWebView2 != null)
+            {
+                _ = webView2_panel_ui.ExecuteScriptAsync($"document.getElementById('mapSelect').value = '{mapName}';");
+            }
+
+            // SPA 라우팅으로 맵이 실제 변경된 경우에만 각종 초기화 작업 재개
+            if (jsExecutor != null)
+            {
+                bool containerReady = await jsExecutor.WaitForQuestContainerAsync(15000);
+
+                await RestorePanelVisibilityAsync(appSettings.latest_map);
+
+                if (containerReady)
                 {
-                    appSettings.latest_map = mapName;
-                    SaveSettings();
+                    await jsExecutor.ExecuteScriptAsync(Constants.ADD_DIRECTION_INDICATORS_SCRIPT);
+                    await jsExecutor.InjectQuestClickListenerAsync();
+                    await RestoreQuestsAsync(appSettings.latest_map);
+                }
+            }
+        }
 
-                    // UI 패널(WhereAmIPanel)의 ComboBox 상태도 함께 변경
-                    if (webView2_panel_ui.CoreWebView2 != null)
-                    {
-                        _ = webView2_panel_ui.ExecuteScriptAsync($"document.getElementById('mapSelect').value = '{mapName}';");
-                    }
+        private string TryExtractMapNameFromUrl(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return null;
+            }
+
+            try
+            {
+                if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+                {
+                    return null;
                 }
 
-                // SPA 라우팅으로 인해 재생성된 DOM 요소에 대응하여 각종 초기화 작업 재개
-                if (jsExecutor != null)
+                string[] segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < segments.Length - 1; i++)
                 {
-                    // Nuxt 컨테이너 로드 대기
-                    bool containerReady = await jsExecutor.WaitForQuestContainerAsync(15000);
-
-                    // 패널 상태 복원: 저장된 값이 있으면 그 상태로, 없으면 현재 맵 전환 시에도 열려 있게 유지
-                    await RestorePanelVisibilityAsync(appSettings.latest_map);
-
-                    if (containerReady)
+                    if (string.Equals(segments[i], "maps", StringComparison.OrdinalIgnoreCase))
                     {
-                        // 맵 재생성 시 증발해버린 스크립트와 리스너를 다시 붙여줌
-                        await jsExecutor.ExecuteScriptAsync(Constants.ADD_DIRECTION_INDICATORS_SCRIPT);
-                        await jsExecutor.InjectQuestClickListenerAsync();
-                        await RestoreQuestsAsync(appSettings.latest_map);
+                        return segments[i + 1].ToLowerInvariant();
                     }
                 }
             }
+            catch
+            {
+            }
+
+            return null;
         }
 
         private async Task RestorePanelVisibilityAsync(string mapName, bool forceOpen = false)

--- a/eft-where-am-i/eft-where-am-i.csproj
+++ b/eft-where-am-i/eft-where-am-i.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <!-- 버전을 여기서만 관리 -->
-    <Version>2.3.5</Version>
+    <Version>2.3.6</Version>
     <AssemblyName>EFT-Where-Am-I</AssemblyName>
     <AssemblyTitle>EFT WHERE AM I v$(Version)</AssemblyTitle>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
이 Pull Request는 `WhereAmI` 사용자 컨트롤에서 맵 변경을 처리하는 로직을 개선하여, 모든 탐색(Navigation) 이벤트가 아니라 **URL에서 실제 맵이 변경된 경우에만** 맵 상태 복원 및 스크립트 삽입이 수행되도록 수정했습니다. 이를 통해 동일한 맵 내에서 이동할 때 발생하는 불필요한 작업을 방지하고, 코드의 안정성과 유지보수성을 향상시켰습니다.

## 맵 변경 감지 및 초기화 개선

- `CoreWebView2_SourceChanged`의 맵 변경 감지 로직을 리팩터링하여, URL의 맵 슬러그(map slug)가 실제로 변경된 경우에만 상태 복원 로직이 실행되도록 수정했습니다.
- URL에서 맵 이름을 안정적으로 추출하는 `TryExtractMapNameFromUrl` 헬퍼 메서드를 추가하여, 코드의 신뢰성과 가독성을 향상시켰습니다.

## 초기화 및 스크립트 삽입 개선

- 초기화 및 스크립트 삽입 로직이 모든 탐색 이벤트에서 실행되지 않고, **맵이 변경된 경우에만** 수행되도록 수정했습니다.
- 이를 통해 필요한 경우에만 스크립트와 이벤트 리스너를 다시 등록하도록 하여 불필요한 중복 작업을 줄였습니다.